### PR TITLE
Increase PHPBrake version constraint to "^0.8.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["airbrake", "laravel"],
     "require": {
         "php": ">=5.4",
-        "airbrake/phpbrake": "^0.7.3",
+        "airbrake/phpbrake": "^0.8.0",
         "illuminate/support": "^5.0|^6.0|^7.0|^8.0"
     },
     "license": "MIT",


### PR DESCRIPTION
I've recently released version [0.8.0 of PHPBrake](https://github.com/airbrake/phpbrake/blob/master/CHANGELOG.md). This version adds the new remote config feature to periodically fetch the project's remote notifier settings and caches them to the system temp dir. The [`remoteConfig` option]( https://github.com/airbrake/phpbrake#remoteconfig) can control this feature. This adds PHPBrake to the list of notifiers that support the remote config feature(Ruby, Go, Java, JavaScript, Python). This increase to the version constraint to adds remote config support to laravel-airbrake.