### PR TITLE
Update illuminate/support version for laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=5.4",
         "airbrake/phpbrake": "^0.7.3",
-        "illuminate/support": "^5.0|^6.0|^7.0|^8.0"
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
When using this library with Laravel 9, it seemed that the `illuminate/support` dependency could not be resolved.
So, I added 9 to the supported versions of `illuminate/support`.